### PR TITLE
Change database connection check

### DIFF
--- a/src/Commands/LAInstall.php
+++ b/src/Commands/LAInstall.php
@@ -88,7 +88,7 @@ class LAInstall extends Command
                 
                 // Checking database
                 $this->line('Checking database...');
-                DB::select('SHOW TABLES');
+                DB::connection()->getDatabaseName();
                 
                 // Running migrations...
                 $this->line('Running migrations...');

--- a/src/Commands/LAInstall.php
+++ b/src/Commands/LAInstall.php
@@ -88,7 +88,7 @@ class LAInstall extends Command
                 
                 // Checking database
                 $this->line('Checking database...');
-                DB::connection()->getDatabaseName();
+                DB::connection()->reconnect();
                 
                 // Running migrations...
                 $this->line('Running migrations...');


### PR DESCRIPTION
The DB::select('SHOW TABLES') command does no't work with SQLITE.
Checking for the name of the database using the DB::connection() class is a more robust and future proof method of determining if there is a working DB connection available.