### PR TITLE
Fieldname should be supplied to Unique check instead of hardcoded del…

### DIFF
--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -1020,7 +1020,7 @@ class Module extends Model
                         }
                     }
                     if($field['unique'] && !$isEdit) {
-                        $col .= "unique:" . $module->name_db . ",deleted_at,NULL";
+                        $col .= "unique:" . $module->name_db . "," . $field['colname'] . ",NULL";
                     }
                     // 'name' => 'required|unique|min:5|max:256',
                     // 'author' => 'required|max:50',


### PR DESCRIPTION
…eted_at

It creates issue while generation count query. It does not create problem in mysql but does create problem in postgres SQL for type mismatch if we are checking unique on a name field.